### PR TITLE
CI upgrade

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,3 +72,15 @@ jobs:
       - name: Run post-build tests
         run: |
           npm run test-build
+
+  passed:
+    if: ${{ ! ( failure() || cancelled() ) }}
+    needs:
+      - validate
+      - test
+      - build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Passed
+        run: |
+          echo "Just happy that it passed."


### PR DESCRIPTION
Repositories can be configured to require PRs to have passed specific jobs. By having a single "success" job we can easily test for it.